### PR TITLE
Initial support for queuing multiple zones

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ var Service, Characteristic;
 
 var Accessory, Service, Characteristic, UUIDGen;
 
+var multi;
+
 module.exports = function(homebridge) {
     console.log("homebridge API version: " + homebridge.version);
 
@@ -344,7 +346,20 @@ RachioPlatform.prototype.updateZoneAccessory = function(accessory, zone) {
                     duration = service.getCharacteristic(Characteristic.SetDuration).value || 300
 
                     client.getZone(accessory.UUID)
-                        .then(zone => zone.start(duration));
+                        .then(zone =>  {
+                            if (multi == null) {
+                                multi = client.multiZone()
+                            }
+                            multi.add(zone, duration)
+                        })
+                        .then(_ => {
+                            setTimeout(() => {
+                                if (multi != null) {
+                                    multi.start()
+                                    multi = null
+                                }
+                            }, 1000);
+                        });
 
                     service.setCharacteristic(Characteristic.RemainingDuration, duration);
                     service.setCharacteristic(Characteristic.InUse, 1);


### PR DESCRIPTION
Relates to #3 

Still needs some work and testing, but I was able to get initial support for MultiZone started.

Things that work:
* Clicking multiple zones within a second starts a queue with those zones.
* Using Siri to ask for multiple zones in a HomeKit "room" to be run like backyard now works.

Things that I've found that don't work quite yet:
* When you click to stop the Quick Run Queue, only one of the zones will be updated by a webhook and updated in the Home app, the rest still say Running.